### PR TITLE
Fixed mistake, header only version of Catch2 is in single_include folder

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('Catch2', 'cpp', default_options : ['cpp_std=c++11'], license : 'Boost', version : '2.2.1')
 
 catch_dep = declare_dependency(
-  include_directories : include_directories('include')
+  include_directories : include_directories('single_include')
 )


### PR DESCRIPTION
Closes #2, maybe later we could add an option to chose between header only and normal version.